### PR TITLE
Add cfg_attr ... no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 /// A pallet template with necessary imports
 
 /// Feel free to remove or edit this file as needed.


### PR DESCRIPTION
Adds the line `#![cfg_attr(not(feature = "std"), no_std)]` back to the pallet template as it was in the module template