### PR TITLE
Fix version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-pallet-template"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-pallet-template"
-version = "0.1.0"
+version = "2.0.0"
 authors = ["Anonymous"]
 edition = "2018"
 
@@ -45,7 +45,7 @@ package = 'frame-system'
 rev = '3e651110aa06aa835790df63410a29676243fc54'
 version = '2.0.0'
 
-[dev-dependencies.sp-io]
+[dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 rev = '3e651110aa06aa835790df63410a29676243fc54'


### PR DESCRIPTION
Fixes version to 2.0.0. Same as node-template.
Change `sp-io` to __dependencies__ instead of __dev-dependencies__. Required to add it to the node.