### PR TITLE
Update to alpha.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 **/*.rs.bk
+
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,7 @@ version = '1.0.0'
 
 [dependencies.frame-support]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-rev = '013c1ee167354a08283fb69915fda56a62fee943'
-version = '2.0.0-alpha.3'
+version = '2.0.0-alpha.5'
 
 [dependencies.safe-mix]
 default-features = false
@@ -34,25 +32,17 @@ version = '1.0.0'
 
 [dependencies.sp-core]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-rev = '013c1ee167354a08283fb69915fda56a62fee943'
-version = '2.0.0-alpha.3'
+version = '2.0.0-alpha.5'
 
 [dependencies.sp-io]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-rev = '013c1ee167354a08283fb69915fda56a62fee943'
-version = '2.0.0-alpha.3'
+version = '2.0.0-alpha.5'
 
 [dependencies.sp-runtime]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-rev = '013c1ee167354a08283fb69915fda56a62fee943'
-version = '2.0.0-alpha.3'
+version = '2.0.0-alpha.5'
 
 [dependencies.system]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
 package = 'frame-system'
-rev = '013c1ee167354a08283fb69915fda56a62fee943'
-version = '2.0.0-alpha.3'
+version = '2.0.0-alpha.5'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# substrate-pallet-template
+# Substrate Pallet Template
 
-This is a template for a Substrate pallet which lives as its own crate so it can be imported into multiple other runtimes. It is based on the ["template" pallet](https://github.com/paritytech/substrate/tree/master/bin/node-template/runtime/src/template.rs) which is included with the [Substrate node template](https://github.com/paritytech/substrate/tree/master/bin/node-template).
+This is a template for a Substrate pallet which lives as its own crate so it can be imported into multiple runtimes. It is based on the ["template" pallet](https://github.com/paritytech/substrate/tree/master/bin/node-template/pallets/template) that is included with the [Substrate node template](https://github.com/paritytech/substrate/tree/master/bin/node-template).
 
 Check out the [HOWTO](HOWTO.md) to learn how to use this for your own runtime module.
 
-This README should act as a general template for distributing your module to others.
+This README should act as a general template for distributing your pallet to others.
 
 ## Purpose
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@ pub trait Trait: system::Trait {
 
 // This pallet's storage items.
 decl_storage! {
+	// It is important to update your storage name so that your pallet's
+	// storage items are isolated from other pallets.
+	// ---------------------------------vvvvvvvvvvvvvv
 	trait Store for Module<T: Trait> as TemplateModule {
 		// Just a dummy storage item.
 		// Here we are declaring a StorageValue, `Something` as a Option<u32>


### PR DESCRIPTION
This is essentially a routine update of the pallet template.

In addition to copying in the code changes from upstream, it also pulls the dependencies from crates.io rather than github.

Finally it adds `Cargo.lock` to the `.gitignore` as recommended [here](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html) for libraries.