### PR TITLE
Upgrade to v2.0.0-rc2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage = 'https://substrate.io'
 license = 'Unlicense'
 name = 'pallet-template'
 repository = 'https://github.com/substrate-developer-hub/substrate-node-template/'
-version = '2.0.0-rc1'
+version = '2.0.0-rc2'
 
 [dependencies.codec]
 default-features = false
@@ -17,32 +17,32 @@ version = '1.3.0'
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'v2.0.0-rc1'
-version = '2.0.0-rc1'
+tag = 'v2.0.0-rc2'
+version = '2.0.0-rc2'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'v2.0.0-rc1'
-version = '2.0.0-rc1'
+tag = 'v2.0.0-rc2'
+version = '2.0.0-rc2'
 
 [dev-dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'v2.0.0-rc1'
-version = '2.0.0-rc1'
+tag = 'v2.0.0-rc2'
+version = '2.0.0-rc2'
 
 [dev-dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'v2.0.0-rc1'
-version = '2.0.0-rc1'
+tag = 'v2.0.0-rc2'
+version = '2.0.0-rc2'
 
 [dev-dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'v2.0.0-rc1'
-version = '2.0.0-rc1'
+tag = 'v2.0.0-rc2'
+version = '2.0.0-rc2'
 
 [features]
 default = ['std']


### PR DESCRIPTION
~~Should we remove `Cargo.lock` from `.gitignore`?~~ No we should...and [here's why](https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries).