### PR TITLE
Adds basic link checker and code builder to CI

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,18 @@
+name: Check Links
+
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -1,0 +1,40 @@
+name: Test Code
+
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+
+jobs:
+  test-code:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+
+      # Steps taken from https://github.com/actions/cache/blob/master/examples.md#rust---cargo
+    - name: Cache cargo registry
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly-2020-05-07
+        components: rustfmt, clippy
+        target: wasm32-unknown-unknown
+        override: true
+        default: true
+
+    - name: Check Code
+      run: cargo check


### PR DESCRIPTION
This PR adds two basic CIs to this repo.

1. Checks the links in all markdown files (Readme and Howto)
2. Runs `cargo check` over the code to help avoid silly mistakes.